### PR TITLE
ENH: Adding .gitignore file to cleanup github status reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Ignore the local directory used to cache the downloaded data
+dicomData
+
+# Ignore the temp files created by jupyter
+.ipynb_checkpoints


### PR DESCRIPTION
Ignore local data cache directory and jupyter temp files in github directories to avoid commit errors.