### PR TITLE
Bump itkwidgets to v1.0a49

### DIFF
--- a/EnvironmentCheck.ipynb
+++ b/EnvironmentCheck.ipynb
@@ -112,7 +112,7 @@
     "    \"monai[nibabel,itk,tqdm]==1.0.1\",\n",
     "    \"nibabel\",\n",
     "    \"tqdm\",\n",
-    "    \"itkwidgets[all]==1.0a23\",\n",
+    "    \"itkwidgets[all]==1.0a49\",\n",
     "    \"imjoy-elfinder\",\n",
     "    \"imjoy-jupyter-extension\",\n",
     "    \"imjoy-jupyterlab-extension\",\n",

--- a/TCIA_Image_Visualization_with_itkWidgets.ipynb
+++ b/TCIA_Image_Visualization_with_itkWidgets.ipynb
@@ -262,7 +262,7 @@
       "outputs": [],
       "source": [
         "# This is the installation required for itkWidgets\n",
-        "!{sys.executable} -m pip install --upgrade --pre -q \"itkwidgets[all]==1.0a23\" imjoy_elfinder"
+        "!{sys.executable} -m pip install --upgrade --pre -q \"itkwidgets[all]==1.0a49\" imjoy_elfinder"
       ]
     },
     {

--- a/TCIA_MONAI_Model_Zoo.ipynb
+++ b/TCIA_MONAI_Model_Zoo.ipynb
@@ -280,7 +280,7 @@
       "outputs": [],
       "source": [
         "# This is the installation required for itkWidgets.\n",
-        "!{sys.executable} -m pip install --upgrade --pre -q \"itkwidgets[all]==1.0a23\" imjoy_elfinder"
+        "!{sys.executable} -m pip install --upgrade --pre -q \"itkwidgets[all]==1.0a48\" imjoy_elfinder"
       ]
     },
     {

--- a/TCIA_RTStruct_SEG_Visualization_with_itkWidgets.ipynb
+++ b/TCIA_RTStruct_SEG_Visualization_with_itkWidgets.ipynb
@@ -259,7 +259,7 @@
       "outputs": [],
       "source": [
         "# This is the installation required for itkWidgets.\n",
-        "!{sys.executable} -m pip install --upgrade --pre -q \"itkwidgets[all]==1.0a23\" imjoy_elfinder"
+        "!{sys.executable} -m pip install --upgrade --pre -q \"itkwidgets[all]==1.0a49\" imjoy_elfinder"
       ]
     },
     {

--- a/TCIA_STL_Visualization_with_itkWidgets.ipynb
+++ b/TCIA_STL_Visualization_with_itkWidgets.ipynb
@@ -295,7 +295,7 @@
       "outputs": [],
       "source": [
         "# This is the installation required for itkWidgets\n",
-        "!{sys.executable} -m pip install --upgrade --pre -q \"itkwidgets[all]==1.0a23\" imjoy_elfinder"
+        "!{sys.executable} -m pip install --upgrade --pre -q \"itkwidgets[all]==1.0a49\" imjoy_elfinder"
       ]
     },
     {

--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,7 @@ dependencies:
     - monai
     - requests
     - itk==5.3.0
-    - itkwidgets[all]==1.0a23
+    - itkwidgets[all]==1.0a49
     - imjoy-jupyterlab-extension
     - pydicom
     - matplotlib


### PR DESCRIPTION
The itkwidgets version is a bit far behind and based on the discussion [here](https://github.com/InsightSoftwareConsortium/itkwidgets/issues/737#issuecomment-1939583673) there appear to be bugs in with Colab notebooks for the 1.0a23 version. Bump to 1.0a49 (the latest).