### PR TITLE
Do not use --pre with itkwidgets install, upgrade versions

### DIFF
--- a/TCIA_MONAI_Model_Zoo.ipynb
+++ b/TCIA_MONAI_Model_Zoo.ipynb
@@ -189,7 +189,7 @@
         "#   that manages all DICOM field values, include acquistion details \n",
         "#   such as voxel image, image orientation, and image directions,\n",
         "#   which are critical to image processing and display.\n",
-        "!{sys.executable} -m pip install --upgrade --pre -q \"itk==5.3.0\"\n",
+        "!{sys.executable} -m pip install --upgrade --pre -q \"itk==5.4.0\"\n",
         "\n",
         "# These are the libraries used to read DICOM Seg objects.\n",
         "!{sys.executable} -m pip install --upgrade --pre -q pydicom\n",
@@ -280,7 +280,7 @@
       "outputs": [],
       "source": [
         "# This is the installation required for itkWidgets.\n",
-        "!{sys.executable} -m pip install --upgrade --pre -q \"itkwidgets[all]==1.0a48\" imjoy_elfinder"
+        "!{sys.executable} -m pip install --upgrade -q \"itkwidgets[all]==1.0a49\" imjoy_elfinder"
       ]
     },
     {

--- a/TCIA_PROSTATEx_Prostate_MRI_Anatomy_Model.ipynb
+++ b/TCIA_PROSTATEx_Prostate_MRI_Anatomy_Model.ipynb
@@ -161,11 +161,8 @@
         "!{sys.executable} -m pip install --upgrade -q --no-deps tcia_utils\n",
         "\n",
         "# This is the installation required for itkWidgets.\n",
-        "!{sys.executable} -m pip install --upgrade --pre -q \"itkwidgets[all]\" imjoy_elfinder\n",
-        "\n",
-        "# TEMPORARY WORKAROUND TO RESOLVE: https://github.com/kirbyju/TCIA_Notebooks/issues/30\n",
-        "!pip uninstall -y zarr ngff_zarr\n",
-        "!pip install zarr ngff_zarr"
+        "!{sys.executable} -m pip install --upgrade -q \"itkwidgets[all]==1.0a53\" imjoy_elfinder\n",
+        "\n"
       ]
     },
     {

--- a/TCIA_RTStruct_SEG_Visualization_with_itkWidgets.ipynb
+++ b/TCIA_RTStruct_SEG_Visualization_with_itkWidgets.ipynb
@@ -205,7 +205,7 @@
         "#   that manages all DICOM field values, include acquistion details \n",
         "#   such as voxel image, image orientation, and image directions,\n",
         "#   which are critical to image processing and display\n",
-        "!{sys.executable} -m pip install --upgrade --pre -q \"itk==5.3.0\"\n",
+        "!{sys.executable} -m pip install --upgrade -q \"itk==5.4.0\"\n",
         "\n",
         "# Install rt-utils for reading DICOM RT-Struct objects.\n",
         "!{sys.executable} -m pip install --upgrade -q rt-utils\n",
@@ -259,7 +259,7 @@
       "outputs": [],
       "source": [
         "# This is the installation required for itkWidgets.\n",
-        "!{sys.executable} -m pip install --upgrade --pre -q \"itkwidgets[all]==1.0a49\" imjoy_elfinder"
+        "!{sys.executable} -m pip install --upgrade -q \"itkwidgets[all]==1.0a53\" imjoy_elfinder"
       ]
     },
     {

--- a/TCIA_STL_Visualization_with_itkWidgets.ipynb
+++ b/TCIA_STL_Visualization_with_itkWidgets.ipynb
@@ -175,7 +175,7 @@
         "#   that manages all DICOM field values, include acquistion details \n",
         "#   such as voxel image, image orientation, and image directions,\n",
         "#   which are critical to image processing and display.\n",
-        "!{sys.executable} -m pip install --upgrade --pre -q \"itk==5.3.0\""
+        "!{sys.executable} -m pip install --upgrade -q \"itk==5.4.0\""
       ]
     },
     {
@@ -295,7 +295,7 @@
       "outputs": [],
       "source": [
         "# This is the installation required for itkWidgets\n",
-        "!{sys.executable} -m pip install --upgrade --pre -q \"itkwidgets[all]==1.0a49\" imjoy_elfinder"
+        "!{sys.executable} -m pip install --upgrade -q \"itkwidgets[all]==1.0a53\" imjoy_elfinder"
       ]
     },
     {

--- a/environment.yml
+++ b/environment.yml
@@ -13,8 +13,8 @@ dependencies:
     - torch
     - monai
     - requests
-    - itk==5.3.0
-    - itkwidgets[all]==1.0a49
+    - itk==5.4.0
+    - itkwidgets[all]==1.0a53
     - imjoy-jupyterlab-extension
     - pydicom
     - matplotlib


### PR DESCRIPTION
`pip install --pre` is likely to pick up zarr version 3 pre-release
packages which are unstable. To address #30.

Also bump `itk` and `itkwidgets` to their latest versions, which contain
many improvements.
